### PR TITLE
updates manifest with correct current info

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,6 @@
     "browser_action": {
         "default_icon": {"16": "static/images/beautifulicon.png"}
     },
-    "default_title": "Portals Test",
 
     "chrome_url_overrides": {
         "newtab": "index.html"}


### PR DESCRIPTION
I figure that we can just keep this branch since we'll probably have to add additional permissions as we go along.  This edit just got rid of that "default_title" error.